### PR TITLE
Define API

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright The OpenTracing Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,73 @@
-# opentracing-lua
+# OpenTracing API for Lua
+Lua implementation of the OpenTracing API http://opentracing.io
+
+## Required Reading
+
+In order to understand the Lua platform API, one must first be familiar with the
+[OpenTracing project](http://opentracing.io) and
+[terminology](http://opentracing.io/documentation/pages/spec) more generally. 
+
+## API overview for those adding instrumentation
+
+Everyday consumers of this `opentracing` package really only need to worry
+about a couple of key abstractions: the `start_span` function, the `Span`
+interface, and binding a `Tracer` at initialization-time. Here are code snippets
+demonstrating some important use cases.
+
+#### Starting an empty trace by creating a "root span"
+
+It's always possible to create a "root" `Span` with no parent or other causal
+reference.
+
+```lua
+    function xyz()
+        ...
+        tracer = --[[ Some Tracer ]]
+        span = tracer:start_span("operation_name")
+        -- Do some work
+        span:finish()
+        ...
+    end
+```
+
+#### Creating a (child) Span given an existing (parent) Span
+
+```lua
+    function qrz(parent_span)
+        ...
+        tracer = --[[ Some Tracer ]]
+        span = tracer:start_span(
+          "operation_name",
+          {["references"] = {{"child_of", parent_span:context()}}})
+        -- Do some work
+        span:finish()
+        ...
+    end
+```
+
+#### Inject Span context into a table
+
+```lua
+    tracer = --[[ Some Tracer ]]
+    carrier = {}
+    span = tracer:start_span('abc')
+    tracer:http_headers_inject(span:context(), carrier)
+```
+
+#### Extract Span context from a TextMapReader
+
+```lua
+    tracer = --[[ Some Tracer ]]
+    carrier = --[[ Some carrier ]]
+    span_context = tracer:http_headers_extract(carrier)
+```
+
+## API compatibility
+
+For the time being, "mild" backwards-incompatible changes may be made without
+changing the major version number. As OpenTracing and `opentracing-cpp` mature,
+backwards compatibility will become more of a priority.
+
+## License
+
+By contributing to opentracing.cpp, you agree that your contributions will be licensed under its [Apache 2.0 License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -70,4 +70,4 @@ backwards compatibility will become more of a priority.
 
 ## License
 
-By contributing to opentracing.cpp, you agree that your contributions will be licensed under its [Apache 2.0 License](./LICENSE).
+By contributing to opentracing.lua, you agree that your contributions will be licensed under its [Apache 2.0 License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ reference.
     tracer:http_headers_inject(span:context(), carrier)
 ```
 
-#### Extract Span context from a TextMapReader
+#### Extract Span context from a table
 
 ```lua
     tracer = --[[ Some Tracer ]]

--- a/opentracing-scm-0.rockspec
+++ b/opentracing-scm-0.rockspec
@@ -1,0 +1,26 @@
+package = "opentracing"
+version = "scm-0"
+
+source = {
+	url = "git+https://github.com/opentracing/opentracing-lua.git";
+}
+
+description = {
+	summary = "Lua platform API for OpenTracing";
+	homepage = "https://github.com/opentracing/opentracing-lua";
+	license = "Apache 2.0";
+}
+
+dependencies = {
+	"lua >= 5.1";
+}
+
+build = {
+	type = "builtin";
+	modules = {
+		["opentracing"] = "opentracing/init.lua";
+		["opentracing.span"] = "opentracing/span.lua";
+		["opentracing.span_context"] = "opentracing/span_context.lua";
+		["opentracing.tracer"] = "opentracing/tracer.lua";
+	};
+}

--- a/opentracing/init.lua
+++ b/opentracing/init.lua
@@ -1,0 +1,3 @@
+return {
+	_VERSION = nil;
+}

--- a/opentracing/init.lua
+++ b/opentracing/init.lua
@@ -1,3 +1,3 @@
 return {
-	_VERSION = nil;
+  _VERSION = nil;
 }

--- a/opentracing/init.lua
+++ b/opentracing/init.lua
@@ -1,3 +1,3 @@
 return {
-  _VERSION = nil;
+  _VERSION = '0.1.0';
 }

--- a/opentracing/span.lua
+++ b/opentracing/span.lua
@@ -8,8 +8,8 @@ local opentracing_span_context = require 'opentracing.span_context'
 
 local span_methods = {}
 local span_mt = {
-	__name = "opentracing.span";
-	__index = span_methods;
+  __name = "opentracing.span";
+  __index = span_methods;
 }
 
 local function new()

--- a/opentracing/span.lua
+++ b/opentracing/span.lua
@@ -40,7 +40,34 @@ end
 --
 -- @param key_values a table of string keys and values of string, bool, or
 --      numeric types
-function log_kv(key_values)
+function span_methods:log_kv(key_values)
+end
+
+--- Stores a Baggage item in the @class `Span` as a key/value pair.
+--
+-- Enables powerful distributed context propagation functionality where
+-- arbitrary application data can be carried along the full path of request 
+-- execution throughout the system.
+--
+-- Note 1: Baggage is only propagated to the future (recursive) children of this
+-- @class `Span`.
+--
+-- Note 2: Baggage is sent in-band with every subsequent local and remote calls,
+-- so this feature must be used with care.
+--
+-- @param key Baggage item key
+--
+-- @param value Baggage item value
+function span_methods:set_baggage_item(key, value)
+end
+
+--- Retrieves value of the baggage item with the given key.
+--
+-- @param key key of the baggage item
+--
+-- @return value of the baggage item with given key or `nil`
+function span_methods:get_baggage_item(key)
+  return nil
 end
 
 return {

--- a/opentracing/span.lua
+++ b/opentracing/span.lua
@@ -90,5 +90,5 @@ function span_methods:get_baggage_item(key)
 end
 
 return {
-  new = new
+  new = new;
 }

--- a/opentracing/span.lua
+++ b/opentracing/span.lua
@@ -1,0 +1,48 @@
+local span_methods = {}
+local span_mt = {
+	__name = "opentracing.span";
+	__index = span_methods;
+}
+
+local function new()
+  return setmetatable({
+  }, span_mt)
+end
+
+--- Indicates the work represented by this @class `Span` has completed or 
+-- terminated.
+--
+-- If `finish` is called a second time, it is guaranteed to do nothing.
+--
+-- @param finish_timestamp (optional) a timestamp represented by microseconds
+--    since the epoch to mark when the span ended. If unspecified, the current
+--    time will be used.
+function span_methods:finish(finish_timestamp)
+end
+
+--- Attaches a key/value pair to the @class `Span`.
+--
+-- The value must be a string, bool, numeric type, or table of such values.
+--
+-- @param key key or name of the tag. Must be a string.
+--
+-- @param value value of the tag
+function span_methods:set_tag(key, value)
+end
+
+--- Attaches a log record to the @class `Span`.
+-- 
+-- For example:
+--
+--    span:log_kv({
+--      ["event"] = "time to first byte",
+--      ["packet.size"] = packet:size()})
+--
+-- @param key_values a table of string keys and values of string, bool, or
+--      numeric types
+function log_kv(key_values)
+end
+
+return {
+  new = new
+}

--- a/opentracing/span.lua
+++ b/opentracing/span.lua
@@ -1,3 +1,11 @@
+-- Span represents a unit of work executed on behalf of a trace. Examples of
+-- spans include a remote procedure call, or a in-process method call to a
+-- sub-component. Every span in a trace may have zero or more causal parents,
+-- and these relationships transitively form a DAG. It is common for spans to
+-- have at most one parent, and thus most traces are merely tree structures.
+
+local opentracing_span_context = require 'opentracing.span_context'
+
 local span_methods = {}
 local span_mt = {
 	__name = "opentracing.span";
@@ -7,6 +15,17 @@ local span_mt = {
 local function new()
   return setmetatable({
   }, span_mt)
+end
+
+--- Provides access to the @class `SpanContext` associated with this @class
+-- `Span`.
+--
+-- The @class `SpanContext` contains state that propagates from @class `Span`
+-- to @class `Span` in a larger tracer.
+--
+-- @return the @class `SpanContext` associated with this @class `Span`
+function span_methods:context()
+  return opentracing_span_context.new()
 end
 
 --- Indicates the work represented by this @class `Span` has completed or 

--- a/opentracing/span_context.lua
+++ b/opentracing/span_context.lua
@@ -10,8 +10,8 @@
 
 local span_context_methods = {}
 local span_context_mt = {
-	__name = "opentracing.span_context";
-	__index = span_context_methods;
+  __name = "opentracing.span_context";
+  __index = span_context_methods;
 }
 
 local function new()

--- a/opentracing/span_context.lua
+++ b/opentracing/span_context.lua
@@ -20,5 +20,5 @@ local function new()
 end
 
 return {
-  new = new
+  new = new;
 }

--- a/opentracing/span_context.lua
+++ b/opentracing/span_context.lua
@@ -1,0 +1,24 @@
+-- SpanContext represents @class `Span` state that must propagate to
+-- descendant @class `Span`\ s and across process boundaries.
+-- 
+-- SpanContext is logically divided into two pieces: the user-level "Baggage"
+--  (see `Span.set_baggage_item` and `Span.get_baggage_item`) that
+--  propagates across @class `Span` boundaries and any
+--  tracer-implementation-specific fields that are needed to identify or
+--  otherwise contextualize the associated @class `Span` (e.g., a ``(trace_id,
+--  span_id, sampled)`` tuple).
+
+local span_context_methods = {}
+local span_context_mt = {
+	__name = "opentracing.span_context";
+	__index = span_context_methods;
+}
+
+local function new()
+  return setmetatable({
+  }, span_context_mt)
+end
+
+return {
+  new = new
+}

--- a/opentracing/tracer.lua
+++ b/opentracing/tracer.lua
@@ -1,3 +1,9 @@
+-- Tracer is the entry point API between instrumentation code and the
+-- tracing implementation.
+-- 
+-- This implementation both defines the public Tracer API, and provides
+-- a default no-op behavior.
+
 local opentracing_span = require "opentracing.span"
 
 local tracer_methods = {}

--- a/opentracing/tracer.lua
+++ b/opentracing/tracer.lua
@@ -118,5 +118,5 @@ function tracer_methods:binary_extract(carrier)
 end
 
 return {
-	new = new
+	new = new;
 }

--- a/opentracing/tracer.lua
+++ b/opentracing/tracer.lua
@@ -8,13 +8,13 @@ local opentracing_span = require "opentracing.span"
 
 local tracer_methods = {}
 local tracer_mt = {
-	__name = "opentracing.tracer";
-	__index = tracer_methods;
+  __name = "opentracing.tracer";
+  __index = tracer_methods;
 }
 
 local function new()
-	return setmetatable({
-	}, tracer_mt)
+  return setmetatable({
+  }, tracer_mt)
 end
 
 --- Starts and returns a new @class `Span` representing a unit of work.
@@ -118,5 +118,5 @@ function tracer_methods:binary_extract(carrier)
 end
 
 return {
-	new = new;
+  new = new;
 }

--- a/opentracing/tracer.lua
+++ b/opentracing/tracer.lua
@@ -1,3 +1,5 @@
+local opentracing_span = require "opentracing.span"
+
 local tracer_methods = {}
 local tracer_mt = {
 	__name = "opentracing.tracer";
@@ -34,6 +36,7 @@ end
 --
 -- @return a @class `Span` instance
 function tracer_methods:start_span(operation_name, options)
+  opentracing_span.new()
 end
 
 --- Injects `span_context` into `carrier`.

--- a/opentracing/tracer.lua
+++ b/opentracing/tracer.lua
@@ -42,7 +42,7 @@ end
 --
 -- @return a @class `Span` instance
 function tracer_methods:start_span(operation_name, options)
-  opentracing_span.new()
+  return opentracing_span.new()
 end
 
 --- Injects `span_context` into `carrier`.

--- a/opentracing/tracer.lua
+++ b/opentracing/tracer.lua
@@ -113,7 +113,7 @@ end
 -- @param carrier a binary storing an injected @class `SpanContext`
 --
 -- @return an extracted @class `SpanContext` or `nil`
-function tracer_metnods:binary_extract(carrier)
+function tracer_methods:binary_extract(carrier)
   return nil
 end
 

--- a/opentracing/tracer.lua
+++ b/opentracing/tracer.lua
@@ -1,0 +1,113 @@
+local tracer_methods = {}
+local tracer_mt = {
+	__name = "opentracing.tracer";
+	__index = tracer_methods;
+}
+
+local function new()
+	return setmetatable({
+	}, tracer_mt)
+end
+
+--- Starts and returns a new @class `Span` representing a unit of work.
+--
+-- Example usage:
+-- 
+-- Create a root @class `Span` (a @class `Span` with no causal references):
+--
+--      tracer:start_span("op-name")
+--
+-- Create a child @class `Span`:
+--  
+--      tracer:start_span(
+--              "op-name", 
+--              {["references"] = {{"child_of", parent_span:context()}}})
+--
+-- @param operation_name name of the operation represented by the new
+--    @class `Span` from the perspective of the current service.
+--
+-- @param options (optional) table specifying modifications to make to the 
+--    newly created span. The following parameters are supported: `references`,
+--    a list of referenced spans; `start_time`, the time to mark when the span
+--    begins (in microseconds since epoch); `tags`, a table of tags to add to
+--    the created span.
+--
+-- @return a @class `Span` instance
+function tracer_methods:start_span(operation_name, options)
+end
+
+--- Injects `span_context` into `carrier`.
+-- 
+-- Example usage:
+--
+--    carrier = {}
+--    tracer:text_map_inject(span:context(), carrier)
+--
+-- @param span_context the @class `SpanContext` instance to inject
+--
+-- @param `carrier` a table to contain the span context
+function tracer_methods:text_map_inject(span_context, carrier)
+end
+
+--- Injects `span_context` into `carrier` using a format appropriate for HTTP
+-- headers.
+-- 
+-- Example usage:
+--
+--    carrier = {}
+--    tracer:http_headers_inject(span:context(), carrier)
+--
+-- @param span_context the @class `SpanContext` instance to inject
+--
+-- @param `carrier` a table to contain the span context
+function tracer_methods:http_headers_inject(span_context, carrier)
+end
+
+--- Returns a binary string representation for `span_context`
+--
+-- Example usage:
+--
+--    s = tracer:binary_inject(span:context())
+--
+-- @param span_context the @class `SpanContext` instance to inject
+--
+-- @return a string representing `span_context`
+function tracer_methods:binary_inject(span_context)
+  return ""
+end
+
+--- Returns a @class `SpanContext` instance extracted from the `carrier` or
+-- `nil` if no such @class `SpanContext` could be found.
+--
+-- @param carrier the format-specific carrier object to extract from
+--
+-- @return an extracted @class `SpanContext` or `nil`
+function tracer_methods:text_map_extract(carrier)
+  return nil
+end
+
+--- Returns a @class `SpanContext` instance extracted from the `carrier` or
+-- `nil` if no such @class `SpanContext` could be found. `http_headers_extract`
+-- expects a format appropriate for HTTP headers and uses case-insensitive
+-- comparisons for the keys.
+--
+-- @param carrier the format-specific carrier object to extract from
+--
+-- @return an extracted @class `SpanContext` or `nil`
+function tracer_methods:http_headers_extract(carrier)
+  return nil
+end
+
+--- Returns a @class `SpanContext` instance extracted from the binary string
+--`carrier` or `nil` if no such @class `SpanContext` could be found.
+--
+-- @param carrier a binary storing an injected @class `SpanContext`
+--
+-- @return an extracted @class `SpanContext` or `nil`
+function tracer_metnods:binary_extract(carrier)
+  return nil
+end
+
+return {
+	new = new
+}


### PR DESCRIPTION
This PR proposes an API for Lua. It builds off of @james-callahan's Kong API https://github.com/Kong/opentracing-lua, but removes the implementation portions that are usually put into basictracer projects (e.g. https://github.com/opentracing/basictracer-python).

The goal with the Lua API is to support these use cases:
* Working with tracers completely written in Lua (for example, Kong's Zipkin tracer https://github.com/sfhardman/kong-plugin-zipkin).
* Loading existing C++ tracers as plugins and using from Lua.
* For C++ applications that embed Lua, bridging and interoperating with the C++ tracers the application may already use.

Given the lack of direct interface support in Lua, the API isn't required as a dependency as it is with the other languages; but conforming tracers are required to implement the methods as documented.

I also wrote a [bridge-tracer](https://github.com/rnburn/lua-bridge-tracer) that implements the API and allows you to use existing C++ tracers through the dynamic loading interface.

Cc @james-callahan, @ror6ax, @isaachier for review.

