### PR TITLE
Add missing span methods.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+version: 2
+jobs:
+  test-lua5.1:
+    docker:
+      - image: ubuntu:18.04
+    steps:
+      - checkout
+      - run: ./ci/setup_build_environment.sh
+      - run: ./ci/do_ci.sh test-5.1
+
+  test-lua5.2:
+    docker:
+      - image: ubuntu:18.04
+    steps:
+      - checkout
+      - run: ./ci/setup_build_environment.sh
+      - run: ./ci/do_ci.sh test-5.2
+
+  test-lua5.3:
+    docker:
+      - image: ubuntu:18.04
+    steps:
+      - checkout
+      - run: ./ci/setup_build_environment.sh
+      - run: ./ci/do_ci.sh test-5.3
+
+workflows:
+  version: 2
+  build_test_and_deploy:
+    jobs:
+      - test-lua5.1
+      - test-lua5.2
+      - test-lua5.3

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:18.04
+
+WORKDIR /3rd_party
+
+ADD setup_build_environment.sh /3rd_party
+
+RUN /3rd_party/setup_build_environment.sh

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -4,8 +4,6 @@ set -e
 
 function run_lua_test()
 {
-  setup_asan_flags
-  ./ci/install_opentracing.sh
   ./ci/install_lua.sh
   ./ci/install_rocks.sh
   luarocks install opentracing-scm-0.rockspec

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+function run_lua_test()
+{
+  setup_asan_flags
+  ./ci/install_opentracing.sh
+  ./ci/install_lua.sh
+  ./ci/install_rocks.sh
+  luarocks install opentracing-scm-0.rockspec
+  busted test/noop.lua
+}
+
+if [[ "$1" == "test-5.3" ]]; then
+  export LUA_VERSION=5.3.4
+  run_lua_test
+  exit 0
+elif [[ "$1" == "test-5.2" ]]; then
+  export LUA_VERSION=5.2.4
+  run_lua_test
+  exit 0
+elif [[ "$1" == "test-5.1" ]]; then
+  export LUA_VERSION=5.1.5
+  run_lua_test
+  exit 0
+fi

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -6,7 +6,7 @@ function run_lua_test()
 {
   ./ci/install_lua.sh
   ./ci/install_rocks.sh
-  luarocks install opentracing-scm-0.rockspec
+  luarocks make opentracing-scm-0.rockspec
   busted test/noop.lua
 }
 

--- a/ci/install_lua.sh
+++ b/ci/install_lua.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+LUA_VERSION="${LUA_VERSION:-5.3.4}"
+cd /
+curl -R -O http://www.lua.org/ftp/lua-$LUA_VERSION.tar.gz
+tar zxf lua-$LUA_VERSION.tar.gz
+cd lua-$LUA_VERSION
+make linux install

--- a/ci/install_rocks.sh
+++ b/ci/install_rocks.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+LUAROCKS_VERSION=2.4.4
+cd /
+wget http://luarocks.github.io/luarocks/releases/luarocks-${LUAROCKS_VERSION}.tar.gz
+tar zxf luarocks-${LUAROCKS_VERSION}.tar.gz
+cd luarocks-${LUAROCKS_VERSION}
+./configure
+make build
+make install
+
+luarocks install busted

--- a/ci/run_docker.sh
+++ b/ci/run_docker.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+BUILD_IMAGE=opentracing-lua
+docker image inspect "$BUILD_IMAGE" &> /dev/null || {
+  docker build -t "$BUILD_IMAGE" ci
+}
+
+if [ -n "$1" ]; then
+  docker run -v "$PWD":/src -w /src -it "$BUILD_IMAGE" /bin/bash -lc "$1"
+else
+  docker run -v "$PWD":/src -w /src --privileged -it "$BUILD_IMAGE" /bin/bash -l
+fi
+

--- a/ci/setup_build_environment.sh
+++ b/ci/setup_build_environment.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+apt-get update 
+apt-get install --no-install-recommends --no-install-suggests -y \
+                ca-certificates \
+                build-essential \
+                software-properties-common \
+                cmake \
+                pkg-config \
+                git \
+                automake \
+                autogen \
+                autoconf \
+                libtool \
+                ssh \
+                wget \
+                curl \
+                unzip \
+                libreadline6-dev \
+                libncurses5-dev

--- a/opentracing/init.lua
+++ b/opentracing/init.lua
@@ -1,3 +1,3 @@
 return {
-  _VERSION = '0.1.0';
+  _VERSION = '0.2.0';
 }

--- a/opentracing/init.lua
+++ b/opentracing/init.lua
@@ -1,3 +1,3 @@
 return {
-  _VERSION = '0.2.0';
+  _VERSION = '0.1.0';
 }

--- a/opentracing/span.lua
+++ b/opentracing/span.lua
@@ -12,8 +12,9 @@ local span_mt = {
   __index = span_methods;
 }
 
-local function new()
+local function new(tracer)
   return setmetatable({
+    ["tracer_"] = tracer
   }, span_mt)
 end
 
@@ -26,6 +27,17 @@ end
 -- @return the @class `SpanContext` associated with this @class `Span`
 function span_methods:context()
   return opentracing_span_context.new()
+end
+
+-- Provides access to the @class `Tracer` that created this span.
+--
+-- @return the @class `Tracer` that created this span.
+function span_methods:tracer()
+  return self.tracer_
+end
+
+-- Changes the operation name.
+function span_methods:set_operation_name(operation_name)
 end
 
 --- Indicates the work represented by this @class `Span` has completed or 

--- a/opentracing/tracer.lua
+++ b/opentracing/tracer.lua
@@ -42,7 +42,7 @@ end
 --
 -- @return a @class `Span` instance
 function tracer_methods:start_span(operation_name, options)
-  return opentracing_span.new()
+  return opentracing_span.new(self)
 end
 
 --- Injects `span_context` into `carrier`.

--- a/test/noop.lua
+++ b/test/noop.lua
@@ -2,7 +2,7 @@ local tracer = require 'opentracing.tracer'
 
 describe("in tracer", function()
   it("supports the construction of a noop tracer", function()
-    local t = opentracing:new()
+    local t = tracer:new()
     local span = t:start_span("abc")
     local context = span:context()
     local t2 = span:tracer()

--- a/test/noop.lua
+++ b/test/noop.lua
@@ -9,7 +9,7 @@ describe("in tracer", function()
     span:set_tag("abc", 123)
     span:log_kv({
         ["event"] = "time to first byte",
-        ["packet.size"] = packet:size()})
+        ["packet.size"] = 100})
     span:set_baggage_item("abc", "123")
     span:get_baggage_item("abc")
     span:finish()

--- a/test/noop.lua
+++ b/test/noop.lua
@@ -1,0 +1,17 @@
+local tracer = require 'opentracing.tracer'
+
+describe("in tracer", function()
+  it("supports the construction of a noop tracer", function()
+    local t = opentracing:new()
+    local span = t:start_span("abc")
+    local context = span:context()
+    local t2 = span:tracer()
+    span:set_tag("abc", 123)
+    span:log_kv({
+        ["event"] = "time to first byte",
+        ["packet.size"] = packet:size()})
+    span:set_baggage_item("abc", "123")
+    span:get_baggage_item("abc")
+    span:finish()
+  end)
+end)


### PR DESCRIPTION
This PR adds the methods `set_operation_name` and `tracer` to `span.lua` (which are in all of the other OpenTracing APIs).

Also, it sets up CI test coverage.